### PR TITLE
Update manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,7 +9,7 @@ env:
   EVENTS: LogMessage,ValueMetric,Error,ContainerMetric
   SKIP_SSL_VALIDATION: false
   NOZZLE_POLLING_PERIOD: 15s
-  LOG_EVENTS_BATCHSIZE: 200
+  LOG_EVENTS_BATCH_SIZE: 200
   SUMO_POST_MINIMUM_DELAY: 200ms
   SUMO_CATEGORY: ExampleCategory
   SUMO_NAME: ExampleName


### PR DESCRIPTION
LOG_EVENTS_BATCHSIZE is being parsed as LOG_EVENTS_BATCH_SIZE in main.go.  This change matches the manifest.yml to the parsed string.  This was a change Pivotal Partners recorded in MC+A repo and needs to be updated in Sumo Logic's code.