### PR TITLE
Update tile.yaml

### DIFF
--- a/tile.yml
+++ b/tile.yml
@@ -30,7 +30,7 @@ packages:
   type: app
   manifest:
     # any options that you would normally specify in a cf manifest.yml, including</i>
-    buildpack: https://github.com/cloudfoundry/go-buildpack.git
+    buildpack: go_buildpack
     command: cloudfoundry-sumologic-nozzle
     instances: 2
     path: sumo-logic-nozzle.zip


### PR DESCRIPTION
converted the buildpack param to use a named reference instead of a URL
buildpack: go_buildpack